### PR TITLE
docs: Fix simple typo, unintentianally -> unintentionally

### DIFF
--- a/django_blog_it/django_blog_it/static/js/jquery.smartmenus.js
+++ b/django_blog_it/django_blog_it/static/js/jquery.smartmenus.js
@@ -35,7 +35,7 @@
 		var eNS = '.smartmenus_mouse';
 		if (!mouseDetectionEnabled && !disable) {
 			// if we get two consecutive mousemoves within 2 pixels from each other and within 300ms, we assume a real mouse/cursor is present
-			// in practice, this seems like impossible to trick unintentianally with a real mouse and a pretty safe detection on touch devices (even with older browsers that do not support touch events)
+			// in practice, this seems like impossible to trick unintentionally with a real mouse and a pretty safe detection on touch devices (even with older browsers that do not support touch events)
 			var firstTime = true,
 				lastMove = null;
 			$(document).bind(getEventsNS([


### PR DESCRIPTION
There is a small typo in django_blog_it/django_blog_it/static/js/jquery.smartmenus.js.

Should read `unintentionally` rather than `unintentianally`.

