### PR TITLE
Readme link issue fixed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,4 +145,4 @@ Visit our Django web development page `Here`_
 We welcome your feedback and support, raise github ticket if you want to report a bug. Need new features? `Contact us here`_
 
 .. _contact us here: https://micropyramid.com/contact-us/
-.. _Here: https://micropyramid.com/django-ecommerce-development/
+.. _Here: https://micropyramid.com/


### PR DESCRIPTION
In the readme file bottom, there is a link to visit django app. But the link is returning a page that's not optimized properly and not working. Instead, I have removed the sub page link and added the base web application link. Now it's pointing the homepage and it's work well.